### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 			"provider": {
 				"name": "scaleway",
 				"secret_key": "{env.SCW_ACCESS_KEY}",
-                "organization_id": "{env.SCW_ORGANIZATION_ID}"
+				"organization_id": "{env.SCW_ORGANIZATION_ID}"
 			}
 		}
 	}
@@ -31,21 +31,15 @@ To use this module for the ACME DNS challenge, [configure the ACME issuer in you
 or with the Caddyfile:
 
 ```
-# globally
-{
-	acme_dns scaleway {
-	    secret_key      = "{env.SCW_ACCESS_KEY}"
-        organization_id = "{env.SCW_ORGANIZATION_ID}"
+tls {
+	dns scaleway {
+		secret_key {env.SCW_ACCESS_KEY}
+		organization_id {env.SCW_ORGANIZATION_ID}
 	}
 }
 ```
 
-```
-# one site
-tls {
-	dns scaleway {
-	    secret_key      = "{env.SCW_ACCESS_KEY}"
-        organization_id = "{env.SCW_ORGANIZATION_ID}"
-	}
-}
-```
+
+## Authenticating
+
+See [the associated README in the libdns package](https://github.com/libdns/scaleway) for important information about credentials.


### PR DESCRIPTION
- Tabs instead of spaces
- Remove redundant Caddyfile global example
- Caddyfile syntax doesn't use `=`, and the quotes aren't necessary
- Added a link to the libdns plugin - typically people will land on this repo, and we should give them a quick link to jump to the libdns plugin which should actually contain information about how to set up authentication