### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ or with the Caddyfile:
 
 ```
 tls {
+	dns_ttl 30m
 	dns scaleway {
 		secret_key {env.SCW_SECRET_KEY}
 		organization_id {env.SCW_ORGANIZATION_ID}


### PR DESCRIPTION
Update the README to include the dns_ttl option
This is required for the scaleway API call, otherwise you get a 400 error and it's not documented anywhere that I could find